### PR TITLE
docs: update streaming user doc page

### DIFF
--- a/docs/user-docs/streaming.md
+++ b/docs/user-docs/streaming.md
@@ -3,29 +3,30 @@ title: Streaming
 ---
 
 # Streaming
-Nerite has the [Superfluid](https://www.superfluid.finance/) protocol built into it, so USND is a native "Super Token" that support streaming. That means you can make real time payments, where USND is sent linearly over time. You can send $0.000001 per second for two weeks, $5 per month for a year, $100 per hour indefinitely... It's completely up to you. 
+Nerite has the [Superfluid](https://superfluid.org/) protocol built into it—-USND is a "[pure Super Token](https://docs.superfluid.org/docs/concepts/overview/super-tokens#pure-super-tokens)" that supports streaming. That means you can make real-time, ongoing USND payments. When you open a stream, USND is sent linearly over time until you edit or close the stream with another transaction. You can send $0.000001 per second for two weeks, $5 per month for a year, $100 per hour indefinitely... It's completely up to you. 
 
 
 :::tip
-USND is the first real time stable currency.
+USND is the first real-time stable currency.
 :::
 
 ## Create a Stream
-Our full UI for this is under development. Check out the Superfluid site to access this feature now. 
+Our full UI for this is under development. Check out the [Superfluid App](https://app.superfluid.org/) to access this feature now. 
 
 ## Receiving a Stream
 You do not have to do anything to accept a stream, and your wallet balance will increase in real time when someone streams to you. No special wallets or anything else needed, as USND is a normal ERC-20 token. 
 
 Streams are not dependent on block times or the L2 sequencer.
 
-## Example Use Cases:
+## Example Use Cases
+Superfluid streams offer exciting new possibilities for programmable money:
 - Annuities that pay out yield earned on a position linearly forever.
-- Onchain subscriptions. Example: stream $25 per month linearly over the course of the month, and cancel at any point to access content or services while the stream is live.
-- Milestone based grants. Instead of giving full grant amounts up front, stream the amount of a period of time while milestones are expected to be reached.
-- Loans which pay themselves off by streaming yield from a yield-bearing collateral to pay down debt. 
+- Onchain subscriptions. Example: stream $25 linearly over a month to maintain access to content or services (and cancel at any point).
+- Milestone-based grants. Instead of giving full grant amounts up front, stream the amount over a period of time while milestones are expected to be reached.
+- Loans that pay themselves off by streaming yield from a yield-bearing collateral to pay down debt. 
 
-Are you building one of these? Let our team know, we want to support you!
+Are you building one of these? Let our team know--we want to support you!
 
 :::tip
-We are working on several Streaming related features and services built on top of Nerite. 
+We are working on several streaming-related features and services built on top of Nerite. 
 :::


### PR DESCRIPTION
Fixes a couple of typos, updates/adds Superfluid links, and updates/adds streaming transaction explanations.